### PR TITLE
Mark all functions passing undefined's to the ffi as unsafe

### DIFF
--- a/rust/eos-rs/src/api/dungeon_mode/dungeon_struct.rs
+++ b/rust/eos-rs/src/api/dungeon_mode/dungeon_struct.rs
@@ -1091,9 +1091,11 @@ impl<'a> GlobalDungeonData<'a> {
     }
 
     /// Opens the message log window.
-    pub fn open_message_log(&mut self, param_1: ffi::undefined4, param_2: ffi::undefined4) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::OpenMessageLog(param_1, param_2) }
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn open_message_log(&mut self, param_1: ffi::undefined4, param_2: ffi::undefined4) {
+        ffi::OpenMessageLog(param_1, param_2)
     }
 
     /// Checks if a given dungeon tip was not displayed yet and if so, displays it.
@@ -1105,25 +1107,29 @@ impl<'a> GlobalDungeonData<'a> {
     }
 
     /// Displays a message in a dialogue box that optionally waits for player input before closing.
-    pub fn display_message(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn display_message(
         &mut self,
         param_1: ffi::undefined4,
         message_id: i32,
         wait_for_input: bool,
     ) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::DisplayMessage(param_1, message_id, wait_for_input as ffi::bool_) }
+        ffi::DisplayMessage(param_1, message_id, wait_for_input as ffi::bool_)
     }
 
     /// Displays a message in a dialogue box that optionally waits for player input before closing.
-    pub fn display_message2(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn display_message2(
         &mut self,
         param_1: ffi::undefined4,
         message_id: i32,
         wait_for_input: bool,
     ) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::DisplayMessage2(param_1, message_id, wait_for_input as ffi::bool_) }
+        ffi::DisplayMessage2(param_1, message_id, wait_for_input as ffi::bool_)
     }
 
     /// Attempts to trigger a forced loss of the type set with [`Self::set_forced_loss_reason`].
@@ -1188,9 +1194,11 @@ impl<'a> GlobalDungeonData<'a> {
     /// (and some others) pass, the function does not return until the leader performs an action.
     ///
     /// Returns true, if the leader has performed an action.
-    pub fn run_leader_turn(&mut self, param_1: ffi::undefined) -> bool {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::RunLeaderTurn(param_1) > 0 }
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn run_leader_turn(&mut self, param_1: ffi::undefined) -> bool {
+        ffi::RunLeaderTurn(param_1) > 0
     }
 
     /// Called at the beginning of [`Self::run_fractional_turn`]. Executed only if
@@ -1230,13 +1238,15 @@ impl<'a> GlobalDungeonData<'a> {
     }
 
     /// Loads the sprite of the specified monster to use it in a dungeon.
-    pub fn load_monster_sprite(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn load_monster_sprite(
         &mut self,
         monster_id: monster_catalog::Type,
         param_2: ffi::undefined,
     ) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::LoadMonsterSprite(monster_id, param_2) }
+        ffi::LoadMonsterSprite(monster_id, param_2)
     }
 
     /// If the monster id parameter is 0x97 (Mew), returns false if either
@@ -1293,13 +1303,18 @@ impl<'a> GlobalDungeonData<'a> {
     }
 
     /// Initializes the team when entering a dungeon.
-    pub fn init_team(&mut self, param_1: ffi::undefined) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe { ffi::InitTeam(param_1) }
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn init_team(&mut self, param_1: ffi::undefined) {
+        ffi::InitTeam(param_1)
     }
 
     /// Initializes a team member. Run at the start of each floor in a dungeon.
-    pub fn init_team_member(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn init_team_member(
         &mut self,
         arg1: monster_catalog::Type,
         type_1: type_catalog::Type,
@@ -1311,20 +1326,17 @@ impl<'a> GlobalDungeonData<'a> {
         param_8: ffi::undefined,
         param_9: ffi::undefined,
     ) {
-        // SAFETY: We hold a valid mutable reference to the global dungeon struct.
-        unsafe {
-            ffi::InitTeamMember(
-                arg1,
-                type_1,
-                type_2,
-                team_member_data,
-                param_5,
-                param_6,
-                param_7,
-                param_8,
-                param_9,
-            )
-        }
+        ffi::InitTeamMember(
+            arg1,
+            type_1,
+            type_2,
+            team_member_data,
+            param_5,
+            param_6,
+            param_7,
+            param_8,
+            param_9,
+        )
     }
 
     /// Spawns the given monster on a tile. Returns None, if the game returned a null-pointer after

--- a/rust/eos-rs/src/api/dungeon_mode/effects.rs
+++ b/rust/eos-rs/src/api/dungeon_mode/effects.rs
@@ -601,7 +601,10 @@ impl DungeonEffectsEmitter {
     /// Lowers the specified offensive stat on the target monster.
     ///
     /// `param_5` and `param_6` are unknown.
-    pub fn lower_offensive_stat(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn lower_offensive_stat(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
@@ -610,14 +613,16 @@ impl DungeonEffectsEmitter {
         param_5: ffi::undefined,
         param_6: ffi::undefined,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe { ffi::LowerOffensiveStat(attacker, defender, stat_idx, n_stages, param_5, param_6) }
+        ffi::LowerOffensiveStat(attacker, defender, stat_idx, n_stages, param_5, param_6)
     }
 
     /// Lowers the specified defensive stat on the target monster.
     ///
     /// `param_5` and `param_6` are unknown.
-    pub fn lower_defensive_stat(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn lower_defensive_stat(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
@@ -626,8 +631,7 @@ impl DungeonEffectsEmitter {
         param_5: ffi::undefined,
         param_6: ffi::undefined,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe { ffi::LowerDefensiveStat(attacker, defender, stat_idx, n_stages, param_5, param_6) }
+        ffi::LowerDefensiveStat(attacker, defender, stat_idx, n_stages, param_5, param_6)
     }
 
     /// Boosts the specified offensive stat on the target monster.
@@ -660,7 +664,10 @@ impl DungeonEffectsEmitter {
     /// Charm and Memento.
     ///
     /// `param_5` is unknown.
-    pub fn apply_offensive_stat_multiplier(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn apply_offensive_stat_multiplier(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
@@ -668,10 +675,7 @@ impl DungeonEffectsEmitter {
         multiplier: i32,
         param_5: ffi::undefined,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe {
-            ffi::ApplyOffensiveStatMultiplier(attacker, defender, stat_idx, multiplier, param_5)
-        }
+        ffi::ApplyOffensiveStatMultiplier(attacker, defender, stat_idx, multiplier, param_5)
     }
 
     /// Applies a multiplier to the specified defensive stat on the target monster.
@@ -680,7 +684,10 @@ impl DungeonEffectsEmitter {
     /// Charm and Memento.
     ///
     /// `param_5` is unknown.
-    pub fn apply_defensive_stat_multiplier(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn apply_defensive_stat_multiplier(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
@@ -688,10 +695,7 @@ impl DungeonEffectsEmitter {
         multiplier: i32,
         param_5: ffi::undefined,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe {
-            ffi::ApplyDefensiveStatMultiplier(attacker, defender, stat_idx, multiplier, param_5)
-        }
+        ffi::ApplyDefensiveStatMultiplier(attacker, defender, stat_idx, multiplier, param_5)
     }
 
     /// Boosts the specified hit chance stat (accuracy or evasion) on the target monster.
@@ -885,7 +889,10 @@ impl DungeonEffectsEmitter {
     /// * `attacker` - The monster that is trying to inflict this status.
     /// * `defender` - The monster that is being inflicted with this status.
     /// * `item` - The item that was used / thrown.
-    pub fn apply_item_effect(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn apply_item_effect(
         &self,
         param_1: ffi::undefined4,
         param_2: ffi::undefined4,
@@ -894,8 +901,7 @@ impl DungeonEffectsEmitter {
         defender: &mut DungeonEntity,
         item: &mut DungeonItem,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe { ffi::ApplyItemEffect(param_1, param_2, param_3, attacker, defender, item) }
+        ffi::ApplyItemEffect(param_1, param_2, param_3, attacker, defender, item)
     }
 
     /// Applies the Violent Seed boost to an entity.
@@ -1076,17 +1082,19 @@ impl<'a> DungeonEffectsInternals<'a> {
     /// * `param_4` - ?
     /// * `param_5` - ?
     /// * `param_6` - ?
-    pub fn apply_damage(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn apply_damage(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
         damage_data: &mut ffi::damage_data,
         param_4: ffi::undefined4,
-        param_5: &mut ffi::undefined4,
-        param_6: &mut ffi::undefined4,
+        param_5: *mut ffi::undefined4,
+        param_6: *mut ffi::undefined4,
     ) -> bool {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe { ffi::ApplyDamage(attacker, defender, damage_data, param_4, param_5, param_6) > 0 }
+        ffi::ApplyDamage(attacker, defender, damage_data, param_4, param_5, param_6) > 0
     }
 
     /// Determines if a move used hits or misses the target.
@@ -1125,24 +1133,24 @@ impl<'a> DungeonEffectsInternals<'a> {
     /// * `the_move` - pointer to move data
     /// * `param_4` - ?
     /// * `param_5` - ?
-    pub fn execute_move_effect(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn execute_move_effect(
         &self,
-        param_1: &mut ffi::undefined4,
+        param_1: *mut ffi::undefined4,
         attacker: &mut DungeonEntity,
         the_move: &Move,
         param_4: ffi::undefined4,
         param_5: ffi::undefined4,
     ) {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe {
-            ffi::ExecuteMoveEffect(
-                param_1,
-                attacker,
-                force_mut_ptr!(the_move),
-                param_4,
-                param_5,
-            )
-        }
+        ffi::ExecuteMoveEffect(
+            param_1,
+            attacker,
+            force_mut_ptr!(the_move),
+            param_4,
+            param_5,
+        )
     }
 
     /// Last function called by [`DungeonEffectsEmitter::deal_damage`] to determine the final
@@ -1156,23 +1164,23 @@ impl<'a> DungeonEffectsInternals<'a> {
     /// * `the_move` - pointer to move data
     /// * `param_4` - ?
     /// * `param_5` - ?
-    pub fn calc_damage_final(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn calc_damage_final(
         &self,
         attacker: &mut DungeonEntity,
         defender: &mut DungeonEntity,
         used_move: &Move,
         param_4: ffi::undefined4,
-        param_5: &mut ffi::undefined4,
+        param_5: *mut ffi::undefined4,
     ) -> i32 {
-        // SAFETY: We have a lease on the overlay existing.
-        unsafe {
-            ffi::CalcDamageFinal(
-                attacker,
-                defender,
-                force_mut_ptr!(used_move),
-                param_4,
-                param_5,
-            )
-        }
+        ffi::CalcDamageFinal(
+            attacker,
+            defender,
+            force_mut_ptr!(used_move),
+            param_4,
+            param_5,
+        )
     }
 }

--- a/rust/eos-rs/src/api/dungeon_mode/mod.rs
+++ b/rust/eos-rs/src/api/dungeon_mode/mod.rs
@@ -36,6 +36,8 @@ use crate::ffi;
 /// # Safety
 /// This resets some global data. The caller needs to make sure pointers to this space
 /// are set up correctly and no references to the area exist.
+///
+/// The caller must make sure the undefined params are valid for this function.
 pub unsafe fn reset_damage_desc(damage_desc: *mut ffi::undefined4, _ov29: &OverlayLoadLease<29>) {
     ffi::ResetDamageDesc(damage_desc);
 }

--- a/rust/eos-rs/src/api/dungeon_mode/monster.rs
+++ b/rust/eos-rs/src/api/dungeon_mode/monster.rs
@@ -90,7 +90,10 @@ pub trait DungeonMonsterExtRead {
     /// damage_out, some other parameters are also unknown.
     ///
     /// The signature of this method WILL change once we figure out what the parameters are.
-    fn calc_recoil_damage_fixed(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn calc_recoil_damage_fixed(
         &self,
         fixed_damage: i32,
         param_3: ffi::undefined4,
@@ -108,7 +111,10 @@ pub trait DungeonMonsterExtRead {
     /// damage_out, some other parameters are also unknown.
     ///
     /// The signature of this method WILL change once we figure out what the parameters are.
-    fn calc_damage_fixed(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn calc_damage_fixed(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -126,7 +132,10 @@ pub trait DungeonMonsterExtRead {
     /// set to [`MoveCategory::None`].
     ///
     /// The signature of this method WILL change once we figure out what the parameters are.
-    fn calc_damage_fixed_no_category(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn calc_damage_fixed_no_category(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -142,7 +151,10 @@ pub trait DungeonMonsterExtRead {
     /// A wrapper (with potential side effects...?) around [`Self::calc_damage_fixed`].
     ///
     /// The signature of this method WILL change once we figure out what the parameters are.
-    fn calc_damage_fixed_wrapper(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn calc_damage_fixed_wrapper(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -161,7 +173,10 @@ pub trait DungeonMonsterExtRead {
     /// One of `param_5` or `param_6` is probably the output struct.
     ///
     /// The signature of this method WILL change once we figure out what the parameters are.
-    fn calc_damage_projectile(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn calc_damage_projectile(
         &self,
         defender: &DungeonEntity,
         used_move: &Move,
@@ -269,7 +284,14 @@ pub trait DungeonMonsterExtWrite {
     fn evolve_this_enemy_if_should(&mut self);
 
     /// Makes the specified monster evolve into the specified species.
-    fn evolve(&mut self, param_2: &mut ffi::undefined4, new_monster_idx: monster_catalog::Type);
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    unsafe fn evolve(
+        &mut self,
+        param_2: *mut ffi::undefined4,
+        new_monster_idx: monster_catalog::Type,
+    );
 
     /// Calculates the speed stage of a monster from its speed up/down counters. The second
     /// parameter is the weight of each counter (how many stages it will add/remove), but appears
@@ -392,7 +414,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         }
     }
 
-    fn calc_recoil_damage_fixed(
+    unsafe fn calc_recoil_damage_fixed(
         &self,
         fixed_damage: i32,
         param_3: ffi::undefined4,
@@ -404,23 +426,21 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         param_9: ffi::undefined4,
         param_10: ffi::undefined4,
     ) {
-        unsafe {
-            ffi::CalcRecoilDamageFixed(
-                force_mut_ptr!(self.1),
-                fixed_damage,
-                param_3,
-                damage_out,
-                move_id,
-                attack_type,
-                param_7,
-                message_type,
-                param_9,
-                param_10,
-            )
-        }
+        ffi::CalcRecoilDamageFixed(
+            force_mut_ptr!(self.1),
+            fixed_damage,
+            param_3,
+            damage_out,
+            move_id,
+            attack_type,
+            param_7,
+            message_type,
+            param_9,
+            param_10,
+        )
     }
 
-    fn calc_damage_fixed(
+    unsafe fn calc_damage_fixed(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -433,24 +453,22 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         param_10: ffi::undefined4,
         param_11: ffi::undefined4,
     ) {
-        unsafe {
-            ffi::CalcDamageFixed(
-                force_mut_ptr!(self.1),
-                force_mut_ptr!(defender),
-                fixed_damage,
-                param_4,
-                damage_out,
-                attack_type,
-                move_category as move_catalog::Type,
-                param_8,
-                message_type,
-                param_10,
-                param_11,
-            )
-        }
+        ffi::CalcDamageFixed(
+            force_mut_ptr!(self.1),
+            force_mut_ptr!(defender),
+            fixed_damage,
+            param_4,
+            damage_out,
+            attack_type,
+            move_category as move_catalog::Type,
+            param_8,
+            message_type,
+            param_10,
+            param_11,
+        )
     }
 
-    fn calc_damage_fixed_no_category(
+    unsafe fn calc_damage_fixed_no_category(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -462,23 +480,21 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         param_9: ffi::undefined4,
         param_10: ffi::undefined4,
     ) {
-        unsafe {
-            ffi::CalcDamageFixedNoCategory(
-                force_mut_ptr!(self.1),
-                force_mut_ptr!(defender),
-                fixed_damage,
-                param_4,
-                damage_out,
-                attack_type,
-                param_7,
-                message_type,
-                param_9,
-                param_10,
-            )
-        }
+        ffi::CalcDamageFixedNoCategory(
+            force_mut_ptr!(self.1),
+            force_mut_ptr!(defender),
+            fixed_damage,
+            param_4,
+            damage_out,
+            attack_type,
+            param_7,
+            message_type,
+            param_9,
+            param_10,
+        )
     }
 
-    fn calc_damage_fixed_wrapper(
+    unsafe fn calc_damage_fixed_wrapper(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -491,24 +507,22 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         param_10: ffi::undefined4,
         param_11: ffi::undefined4,
     ) {
-        unsafe {
-            ffi::CalcDamageFixedWrapper(
-                force_mut_ptr!(self.1),
-                force_mut_ptr!(defender),
-                fixed_damage,
-                param_4,
-                damage_out,
-                attack_type,
-                move_category as move_catalog::Type,
-                param_8,
-                param_9,
-                param_10,
-                param_11,
-            )
-        }
+        ffi::CalcDamageFixedWrapper(
+            force_mut_ptr!(self.1),
+            force_mut_ptr!(defender),
+            fixed_damage,
+            param_4,
+            damage_out,
+            attack_type,
+            move_category as move_catalog::Type,
+            param_8,
+            param_9,
+            param_10,
+            param_11,
+        )
     }
 
-    fn calc_damage_projectile(
+    unsafe fn calc_damage_projectile(
         &self,
         defender: &DungeonEntity,
         used_move: &Move,
@@ -516,16 +530,14 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterRef<'a> {
         param_5: ffi::undefined4,
         param_6: ffi::undefined4,
     ) {
-        unsafe {
-            ffi::CalcDamageProjectile(
-                force_mut_ptr!(self.1),
-                force_mut_ptr!(defender),
-                force_mut_ptr!(used_move),
-                move_power,
-                param_5,
-                param_6,
-            )
-        }
+        ffi::CalcDamageProjectile(
+            force_mut_ptr!(self.1),
+            force_mut_ptr!(defender),
+            force_mut_ptr!(used_move),
+            move_power,
+            param_5,
+            param_6,
+        )
     }
 
     fn is_aura_bow_active(&self) -> bool {
@@ -698,7 +710,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterMut<'a> {
         )
     }
 
-    fn calc_recoil_damage_fixed(
+    unsafe fn calc_recoil_damage_fixed(
         &self,
         fixed_damage: i32,
         param_3: ffi::undefined4,
@@ -723,7 +735,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterMut<'a> {
         )
     }
 
-    fn calc_damage_fixed(
+    unsafe fn calc_damage_fixed(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -750,7 +762,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterMut<'a> {
         )
     }
 
-    fn calc_damage_fixed_no_category(
+    unsafe fn calc_damage_fixed_no_category(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -775,7 +787,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterMut<'a> {
         )
     }
 
-    fn calc_damage_fixed_wrapper(
+    unsafe fn calc_damage_fixed_wrapper(
         &self,
         defender: &DungeonEntity,
         fixed_damage: i32,
@@ -802,7 +814,7 @@ impl<'a> DungeonMonsterExtRead for DungeonMonsterMut<'a> {
         )
     }
 
-    fn calc_damage_projectile(
+    unsafe fn calc_damage_projectile(
         &self,
         defender: &DungeonEntity,
         used_move: &Move,
@@ -898,8 +910,12 @@ impl<'a> DungeonMonsterExtWrite for DungeonMonsterMut<'a> {
         unsafe { ffi::EnemyEvolution(force_mut_ptr!(self.1)) }
     }
 
-    fn evolve(&mut self, param_2: &mut ffi::undefined4, new_monster_idx: monster_catalog::Type) {
-        unsafe { ffi::EvolveMonster(force_mut_ptr!(self.1), param_2, new_monster_idx) }
+    unsafe fn evolve(
+        &mut self,
+        param_2: *mut ffi::undefined4,
+        new_monster_idx: monster_catalog::Type,
+    ) {
+        ffi::EvolveMonster(force_mut_ptr!(self.1), param_2, new_monster_idx)
     }
 
     /// Calculates the speed stage of a monster from its speed up/down counters. The second

--- a/rust/eos-rs/src/api/gameplay.rs
+++ b/rust/eos-rs/src/api/gameplay.rs
@@ -595,20 +595,19 @@ pub fn get_monster_level_from_spawn_entry(spawn_entry: &ffi::monster_spawn_entry
 ///
 /// You should not use this in dungeon mode.
 /// Use [`crate::api::dungeon_mode::DungeonEffectsEmitter::apply_gummi_boosts`] instead.
-pub fn apply_gummi_boosts(
-    param_1: &mut ffi::undefined2,
-    param_2: &mut ffi::undefined2,
-    param_3: &mut ffi::undefined,
-    param_4: &mut ffi::undefined,
+///
+/// # Safety
+/// The caller must make sure the undefined params and buffer are valid for this function.
+pub unsafe fn apply_gummi_boosts(
+    param_1: *mut ffi::undefined2,
+    param_2: *mut ffi::undefined2,
+    param_3: *mut ffi::undefined,
+    param_4: *mut ffi::undefined,
     param_5: ffi::undefined2,
     param_6: ffi::undefined,
-    buffer: &mut crate::ctypes::c_void,
+    buffer: *mut crate::ctypes::c_void,
 ) {
-    unsafe {
-        ffi::ApplyGummiBoostsGroundMode(
-            param_1, param_2, param_3, param_4, param_5, param_6, buffer,
-        )
-    }
+    ffi::ApplyGummiBoostsGroundMode(param_1, param_2, param_3, param_4, param_5, param_6, buffer)
 }
 
 /// Returns the maximum rescue attempts allowed in the specified dungeon,

--- a/rust/eos-rs/src/api/ground_mode.rs
+++ b/rust/eos-rs/src/api/ground_mode.rs
@@ -72,14 +72,17 @@ impl GroundModeContext {
     ///               [`script_opcode_catalog::OPCODE_PROCESS_SPECIAL`]
     /// * `arg2`    - second argument, if relevant? Probably corresponds to the third parameter of
     ///               [`script_opcode_catalog::OPCODE_PROCESS_SPECIAL`]
-    pub fn script_special_process_call(
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn script_special_process_call(
         &mut self,
-        param_1: &mut ffi::undefined4,
+        param_1: *mut ffi::undefined4,
         id: special_process_catalog::Type,
         arg1: i32,
         arg2: i32,
     ) -> i32 {
-        unsafe { ffi::ScriptSpecialProcessCall(param_1, id, arg1, arg2) }
+        ffi::ScriptSpecialProcessCall(param_1, id, arg1, arg2)
     }
 
     /// Returns an entry from RECRUITMENT_TABLE_SPECIES.
@@ -102,8 +105,11 @@ impl GroundModeContext {
     /// # Arguments
     /// * `job_type` - job type? 0 is a random NPC job, 1 is a bottle mission
     /// * `param_2`  - ???
-    pub fn init_random_npc_jobs(&mut self, job_type: i32, param_2: ffi::undefined2) {
-        unsafe { ffi::InitRandomNpcJobs(job_type, param_2) }
+    ///
+    /// # Safety
+    /// The caller must make sure the undefined params are valid for this function.
+    pub unsafe fn init_random_npc_jobs(&mut self, job_type: i32, param_2: ffi::undefined2) {
+        ffi::InitRandomNpcJobs(job_type, param_2)
     }
 
     /// Implements SPECIAL_PROC_GET_RANDOM_NPC_JOB_TYPE.


### PR DESCRIPTION
I think this is a good idea, since the game will just take whatever was passed in and since Rust has no idea what it is, this is unsafe.