### PR TITLE
Added info about the alignment of the origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ error "section '.text' will not fit in region 'out'"
 ### Expanding the available space
 To work around this issue, you can extend the space allocated in the overlay. **If you decide to extend the space, you do so at your own risk. Be careful since this space might be used by future patches!** Check the [list of assigned areas](https://docs.google.com/document/d/1Rs4icdYtiM6KYnWxMkdlw7jpWrH7qw5v6LOfDWIiYho) to find out if patches used in your ROM are affected.
 
-The value of the Origin must a multiple of 16 (end with 0 in hexadecimal). That mean the added amount of bytes must also be a multiple of 16.
+The value of `ORIGIN` must a multiple of 16 (end with 0 in hexadecimal). Therefore, the amount of bytes added to `LENGTH` must also be a multiple of 16.
 
 To extend the allocated space, open `linker.ld` and edit the following line:
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ error "section '.text' will not fit in region 'out'"
 ### Expanding the available space
 To work around this issue, you can extend the space allocated in the overlay. **If you decide to extend the space, you do so at your own risk. Be careful since this space might be used by future patches!** Check the [list of assigned areas](https://docs.google.com/document/d/1Rs4icdYtiM6KYnWxMkdlw7jpWrH7qw5v6LOfDWIiYho) to find out if patches used in your ROM are affected.
 
+The value of the Origin must a multiple of 16 (end with 0 in hexadecimal). That mean the added amount of bytes must also be a multiple of 16.
+
 To extend the allocated space, open `linker.ld` and edit the following line:
 ```
 out     : ORIGIN = 0x23D7FF0, LENGTH = 0x8010


### PR DESCRIPTION
It’s something I have experimentally figured out. Still don’t know why it need that, but if it isn’t aligned on 16 bytes, then (at least) the function that jump to the Special Process trampoline isn’t correct, as it jump a few (in my test, 8) bytes after the first opcode of this trampoline.