### PR TITLE
Minor fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ If you want to build pure C projects, continue below.
     3. Select the *ExtraSpace* patch and click *Apply*
 6. Place the ROM in `[project root]/rom.nds`
     - **US ROM offsets are used by default.** If you're using a EU ROM, change the `REGION` variable in `Makefile` to `EU`.
-7. If you are using Linux, install [armips](https://github.com/Kingcom/armips) manually. On macOS, you might need to do the following:
-  - Navigate to the folder `bin/armips` in Finder
-  - Right-click `armips-mac-x64`, click "Open" and confirm
+7. Follow these steps depending on your operating system:
+    - If you are using Linux, install [armips](https://github.com/Kingcom/armips) manually.
+    - If you are encountering errors with armips on Windows, you might need to install the [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48145).
+    - On macOS, you might need to do the following:
+      - Navigate to the folder `bin/armips` in Finder
+      - Right-click `armips-mac-x64`, click "Open" and confirm
 8. (optional) Run `make header-comments` to generate documentation comments for IDEs.
 
 ## Building

--- a/include/cot/logging.h
+++ b/include/cot/logging.h
@@ -24,7 +24,7 @@
 #define COT_ASSERT(expr) \
   if (!(expr)) {\
     DebugPrint(2, "ASSERTION FAILED: " #expr " (" __FILE__ ":" _COT_INTERNAL_STRINGIZE(__LINE__) ")"); \
-    *((char*) 0) = 1; \
+    WaitForever(); \
   }
 
 #else

--- a/scripts/generate_linkerscript.py
+++ b/scripts/generate_linkerscript.py
@@ -14,7 +14,7 @@ all_symbols = set()
 linkerscript_lines.append("/* THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")
 
 for yaml_file_path in Path("pmdsky-debug/symbols").rglob("*.yml"):
-  with open(yaml_file_path, 'r') as f:
+  with open(yaml_file_path, 'r', encoding="utf-8") as f:
     linkerscript_lines.append("")
     linkerscript_lines.append(f"/* --- {yaml_file_path} --- */")
     yaml_string = f.read()
@@ -60,7 +60,7 @@ for yaml_file_path in Path("pmdsky-debug/symbols").rglob("*.yml"):
           linkerscript_lines.append(f"{name} = {hex(addr)};")
           all_symbols.add(name)
 
-with open(f"symbols/generated_{region}.ld", "w") as f:
+with open(f"symbols/generated_{region}.ld", "w", encoding="utf-8") as f:
   for line in linkerscript_lines:
     f.write(line)
     f.write('\n')

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -73,7 +73,7 @@ def apply_binary_patches():
     os.mkdir("build/binaries")
 
   # Write all symbols to a file that can be included in patches
-  with open("build/binaries/symbols.asm", "w") as f:
+  with open("build/binaries/symbols.asm", "w", encoding="utf-8") as f:
     # Write symbols
     for symbol, offset in overlay_symbols_lookup.items():
       f.write(f".definelabel {symbol},{hex(offset)}\n")


### PR DESCRIPTION
- Specifies UTF-8 as the string encoding in Python scripts
- Fixes `COT_ASSERT` not working as intended
- Adds a link to the Visual C++ redistributable download (see https://github.com/SkyTemple/c-of-time/pull/249#issuecomment-1716170657)