### PR TITLE
Re-enable file paths in logging macros and make them relative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ ARCH	:=	-marm -mno-thumb-interwork
 CFLAGS	:=	-g -Wall $(OPT_LEVEL) $(RELEASE_CONFIG) $(SP_EFFECT_COMPAT) \
  			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer -fno-short-enums \
 			-ffast-math -fno-builtin \
+			-fmacro-prefix-map=$(realpath $(CURDIR)/..)=. \
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9 -flto

--- a/include/cot/logging.h
+++ b/include/cot/logging.h
@@ -10,13 +10,8 @@
 
 #ifndef NDEBUG
 
-// Uncomment this to include file and line number in log messages (risk of doxxing!)
-/* #define _COT_INTERNAL_LOG_MESSAGE(category, format) \
- *   "[" category "] " format " (" __FILE__ ":" _COT_INTERNAL_STRINGIZE(__LINE__) ")"
- */
-
 #define _COT_INTERNAL_LOG_MESSAGE(category, format) \
-  "[" category "] " format
+  "[" category "] " format " (" __FILE__ ":" _COT_INTERNAL_STRINGIZE(__LINE__) ")"
 
 #define COT_LOG(category, format)           DebugPrint(0, _COT_INTERNAL_LOG_MESSAGE(category, format))
 #define COT_WARN(category, format)          DebugPrint(1, _COT_INTERNAL_LOG_MESSAGE(category, format))
@@ -28,17 +23,9 @@
 
 #define COT_ASSERT(expr) \
   if (!(expr)) {\
-    DebugPrint(2, "ASSERTION FAILED: " #expr); \
+    DebugPrint(2, "ASSERTION FAILED: " #expr " (" __FILE__ ":" _COT_INTERNAL_STRINGIZE(__LINE__) ")"); \
     WaitForever(); \
   }
-
-// Uncomment this to include file and line number in assertion messages (risk of doxxing!)
-/* #define COT_ASSERT(expr) \
- *   if (!(expr)) {\
- *     DebugPrint(2, "ASSERTION FAILED: " #expr " (" __FILE__ ":" _COT_INTERNAL_STRINGIZE(__LINE__) ")"); \
- *     WaitForever(); \
- *   }
- */
 
 #else
 


### PR DESCRIPTION
Followup for https://github.com/SkyTemple/c-of-time/pull/251

![image](https://github.com/SkyTemple/c-of-time/assets/65084428/130ea6f5-6f8f-4dbe-b236-f9835e304b0b)
