### PR TITLE
Support segmented code with sections for C patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-T $(CURDIR)/../symbols/generated_$(REGION).ld \
 			-T $(CURDIR)/../symbols/custom_$(REGION).ld -T $(CURDIR)/../linker.ld \
-			-g $(ARCH) -Wl,-Map,$(notdir $*.map) -Xlinker -no-enum-size-warning -nostdlib
+			-g $(ARCH) -Wl,-Map,$(notdir $*.map) -Xlinker -no-enum-size-warning -nostdlib  -Xlinker --no-check-sections
 
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
@@ -151,7 +151,7 @@ buildobjs:
 .PHONY: clean
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).bin $(TARGET).asm $(ROM_OUT).nds symbols/generated_*.ld
+	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).asm $(ROM_OUT).nds symbols/generated_*.ld
  
 #---------------------------------------------------------------------------------
 else
@@ -162,10 +162,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 # main targets
 #---------------------------------------------------------------------------------
 
-$(OUTPUT).bin : $(OUTPUT).elf
-	arm-none-eabi-objcopy -O binary $(OUTPUT).elf $(OUTPUT).bin
-
-$(OUTPUT).elf	:	$(OFILES)
+$(OUTPUT).elf	:	$(CURDIR)/../linker.ld $(OFILES)
 
 .PHONY: buildobjs
 buildobjs: $(OFILES)
@@ -181,7 +178,7 @@ symbols/generated_$(REGION).ld:
 
 .PHONY: patch
 patch: build
-	$(PYTHON) scripts/patch.py $(REGION) $(ROM) $(OUTPUT).bin $(OUTPUT).elf $(ROM_OUT)
+	$(PYTHON) scripts/patch.py $(REGION) $(ROM) $(OUTPUT).elf $(ROM_OUT)
 
 .PHONY: asmdump
 asmdump: build

--- a/linker.ld
+++ b/linker.ld
@@ -15,8 +15,8 @@ SECTIONS {
                 This allows to spread your code on different overlays
                 You can change the section of one symbol (function or variable) in your C code using: __attribute__((section(".YOURSECTIONNAME")))
                 Note that section names are standardized and in the form ".text.OV.NB.SPECIAL"
-                Where OV is between 'ov9' (ARM9 Overlay) and 'arm' (Main ARM Binary)
-                NB is the OV number (7 or 9 for 'arm', any ARM9 Overlay number for 'ov9')
+                Where OV is between 'ov' (ARM9 Overlay) and 'arm' (Main ARM Binary)
+                NB is the OV number (7 or 9 for 'arm', any ARM9 Overlay number for 'ov')
                 SPECIAL is a distinct name, this is only to distinguish between 2 sections on the same overlay
         */
         /*.text.OV.NB.SPECIAL : {
@@ -26,7 +26,7 @@ SECTIONS {
                 Main Section (Default section, in ARM9 overlay 36)
                 Note that you should add your special sections before that
         */
-        .text.ov9.36.main : {
+        .text.ov.36.main : {
                 *(.init)
                 *(.text)
                 *(.text.*)

--- a/linker.ld
+++ b/linker.ld
@@ -1,30 +1,31 @@
 OUTPUT_ARCH(arm)
 MEMORY {
-        out     : ORIGIN = 0x23D7FF0, LENGTH = 0x8010
+        main    : ORIGIN = 0x23D7FF0, LENGTH = 0x8010
+        /* Change/Add memory locations here */
+        /* NEW    : ORIGIN = 0x2000000, LENGTH = 0x800 */
 }
 
 SECTIONS {
-        .text : {
-
-                FILL (0xABCD)
-
-                __exidx_start = .;
-                __exidx_end = .;
-                abort = .;
-
-                __text_start = . ;
-
-                __init_array_start = .;
-                KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*)))
-                KEEP (*(.init_array))
-                __init_array_end = .;
-                __fini_array_start = .;
-                KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
-                KEEP (*(.fini_array))
-                __fini_array_end = .;
-                
+        /*
+                Add more sections for the linker, each section using a different memory location
+                This allows to spread your code on different overlays
+                You can change the section of one symbol (function or variable) in your C code using: __attribute__((section(".YOURSECTIONNAME")))
+                Note that section names are standardized and in the form ".text.OV.NB.SPECIAL"
+                Where OV is between 'ov9' (ARM9 Overlay) and 'arm' (Main ARM Binary)
+                NB is the OV number (7 or 9 for 'arm', any ARM9 Overlay number for 'ov9')
+                SPECIAL is a distinct name, this is only to distinguish between 2 sections on the same overlay
+        */
+        /*.text.OV.NB.SPECIAL : {
+                *(.YOURSECTIONNAME)
+        } >NEW = 0xff*/
+        /*
+                Main Section (Default section, in ARM9 overlay 36)
+                Note that you should add your special sections before that
+        */
+        .text.ov9.36.main : {
                 *(.init)
                 *(.text)
+                *(.text.*)
                 *(.fini)
                 *(.ctors)
                 *(.dtors)
@@ -33,13 +34,7 @@ SECTIONS {
                 *(.data)
                 *(.data.*)
                 *(COMMON)
-                __text_end  = . ;
                 . = ALIGN(4);
-                __bss_start__ = . ;
                 *(.bss)
-                __bss_end__ = . ;
-
-                _end = __bss_end__ ;
-                __end__ = __bss_end__ ;
-        } >out = 0xff
+        } >main = 0xff
 }

--- a/linker.ld
+++ b/linker.ld
@@ -1,5 +1,9 @@
 OUTPUT_ARCH(arm)
 MEMORY {
+        /* 
+                Overlay load address + offset to common area
+                see https://docs.google.com/document/d/1Rs4icdYtiM6KYnWxMkdlw7jpWrH7qw5v6LOfDWIiYho
+        */
         main    : ORIGIN = 0x23D7FF0, LENGTH = 0x8010
         /* Change/Add memory locations here */
         /* NEW    : ORIGIN = 0x2000000, LENGTH = 0x800 */

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -94,7 +94,8 @@ def apply_overlay():
           
           # Combine the existing overlay bytes with the custom code
           padding = vma - ram_address
-          new_overlay_bytes = bytearray(overlay_bytes)
+          new_overlay_bytes = bytearray(padding + size)
+          new_overlay_bytes[0:len(overlay_bytes)] = overlay_bytes
           new_overlay_bytes[padding:padding + size] = custom_code_bytes
 
           if hierarchy[2] == "ov9":

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -64,7 +64,7 @@ def apply_overlay():
           vma = int(section[3], 16)
           offset = int(section[5], 16)
           bank_number = int(hierarchy[3])
-          if hierarchy[2] == "ov9":
+          if hierarchy[2] == "ov":
             overlay = overlays[bank_number]
             overlay_bytes = rom.files[overlay.fileID]
             ram_address = overlay.ramAddress
@@ -98,7 +98,7 @@ def apply_overlay():
           new_overlay_bytes[0:len(overlay_bytes)] = overlay_bytes
           new_overlay_bytes[padding:padding + size] = custom_code_bytes
 
-          if hierarchy[2] == "ov9":
+          if hierarchy[2] == "ov":
             overlay.data = new_overlay_bytes
             overlay.save()
             rom.files[overlay.fileID] = new_overlay_bytes

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -11,9 +11,6 @@ import tempfile
 
 OVERLAY_EXTRA = 36
 
-# Overlay load address + offset to common area
-# see https://docs.google.com/document/d/1Rs4icdYtiM6KYnWxMkdlw7jpWrH7qw5v6LOfDWIiYho
-
 region = sys.argv[1]
 rom_path = sys.argv[2]
 overlay_elf_path = sys.argv[3]
@@ -70,11 +67,14 @@ def apply_overlay():
           if hierarchy[2] == "ov9":
             overlay = overlays[bank_number]
             overlay_bytes = rom.files[overlay.fileID]
+            ram_address = overlay.ramAddress
           elif hierarchy[2] == "arm":
             if bank_number == 9:
               overlay_bytes = rom.arm9
+              ram_address = rom.arm9RamAddress
             elif bank_number == 7:
               overlay_bytes = rom.arm7
+              ram_address = rom.arm7RamAddress
             else:
               raise ValueError("Invalid arm binary '%d'"%bank_number)
           else:
@@ -93,7 +93,7 @@ def apply_overlay():
           assert size == len(custom_code_bytes), f"Size mismatch"
           
           # Combine the existing overlay bytes with the custom code
-          padding = vma - overlay.ramAddress
+          padding = vma - ram_address
           new_overlay_bytes = bytearray(overlay_bytes)
           new_overlay_bytes[padding:padding + size] = custom_code_bytes
 


### PR DESCRIPTION
Allows C code to be compiled and spread across all overlays, using linker sections.
All memory regions are defined directly in the linker script and not hardcoded to the patch.py script.
- Rewrites main linker script to the new naming convention and add doc on how to add memory sections
- Adds an option to the linker to not check for section overlap (useful in case you need to compile to different overlays at the same address)
- Rewrite patch.py to read section info (affected overlay, load address, contents) directly from the .elf file and patch on a per section basis

Warning: currently, .init_array and .fini_array section are not defined and not supported!