### PR TITLE
Implement ground instruction routine feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want to build pure C projects, continue below.
 
 ### Preparing the ROM
 
-You need a US or EU ROM of Pokémon Mystery Dungeon: Explorers of Sky. The ROM must be patched with the [`ExtraSpace` patch by End45](https://github.com/End45/EoS-asm-hacks/blob/main/src/ExtraSpace.asm). You can apply the patch with [SkyTemple](https://skytemple.org):
+You need a US, EU, or JP ROM of Pokémon Mystery Dungeon: Explorers of Sky. The ROM must be patched with the [`ExtraSpace` patch by Frostbyte](https://github.com/Frostbyte0x70/EoS-asm-patches/blob/main/src/ExtraSpace.asm). You can apply the patch with [SkyTemple](https://skytemple.org):
   1. Open the ROM in SkyTemple
   2. Click *ASM Patches* (*Patches > ASM* in SkyTemple 1.4+) and switch to the *Utility* tab
   3. Select the *ExtraSpace* patch and click *Apply*
@@ -77,7 +77,6 @@ Advantages over special processes include:
 
 Disadvantages:
 - No built-in support in SkyTemple (workaround provided below)
-- No support for return values at the moment (the variable $EVENT_LOCAL is used as a "return register" by convention)
 
 Custom instructions are disabled by default. To enable support for custom instructions in c-of-time, open the file `include/cot/custom_instructions.h` and change the line `#define CUSTOM_GROUND_INSTRUCTIONS 0` to `#define CUSTOM_GROUND_INSTRUCTIONS 1`. You can now add your own instructions to the `CUSTOM_INSTRUCTIONS` array in `ground_instructions.c`.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ Advantages over special processes include:
 - No frame delay (especially beneficial when building complex minigames or other real-time interactions)
 - Custom instructions can be used inside targeted routines, while `ProcessSpecial` doesn't work
 - Cleaner script code overall without resorting to macros
+- Performing entity-specific operations
 
 Disadvantages:
+- At the moment, routines cannot conditionally hang on custom instructions (as opposed to special processes, which can hang the routine and loop its code upon returning -1)
 - No built-in support in SkyTemple (workaround provided below)
+
+Like special processes, custom instructions are capable of returning a value that can then be checked with a switch-statement. For an example, see the custom instruction `CheckInputStatus` in `ground_instructions.c`.
 
 Custom instructions are disabled by default. To enable support for custom instructions in c-of-time, open the file `include/cot/custom_instructions.h` and change the line `#define CUSTOM_GROUND_INSTRUCTIONS 0` to `#define CUSTOM_GROUND_INSTRUCTIONS 1`. You can now add your own instructions to the `CUSTOM_INSTRUCTIONS` array in `ground_instructions.c`.
 

--- a/include/cot/custom_instructions.h
+++ b/include/cot/custom_instructions.h
@@ -8,10 +8,10 @@
 
 struct custom_instruction {
   int8_t n_params;
-  void (*handler)(uint16_t* args);
+  void (*handler)(struct script_routine* routine, uint16_t* args);
   char *name;
 };
 
-void DispatchCustomInstruction(int index, uint16_t* args);
+void DispatchCustomInstruction(int index, struct script_routine* routine, uint16_t* args);
 extern struct custom_instruction CUSTOM_INSTRUCTIONS[];
 extern const int CUSTOM_INSTRUCTION_AMOUNT;

--- a/src/cot/instruction_hooks.c
+++ b/src/cot/instruction_hooks.c
@@ -21,7 +21,8 @@ __attribute((naked)) void NewInstructions(void) {
     asm volatile("sub r5,r5,r7");
 
     asm volatile("mov r0,r5"); // Opcode (offset from FIRST_CUSTOM_OPCODE)
-    asm volatile("mov r1,r6"); // Argument list
+    asm volatile("mov r1,r4"); // Current script routine pointer
+    asm volatile("mov r2,r6"); // Argument list
     asm volatile("bl DispatchCustomInstruction");
 
     asm volatile("b ScriptEngineReturnTwo");
@@ -43,7 +44,7 @@ __attribute((naked)) void HookGetParameterCount(void) {
     asm volatile(".ltorg");
 }
 
-__attribute((used)) void DispatchCustomInstruction(int index, uint16_t* args) {
+__attribute((used)) void DispatchCustomInstruction(int index, struct script_routine* routine, uint16_t* args) {
     if (index < 0 || index >= CUSTOM_INSTRUCTION_AMOUNT) {
         COT_ERRORFMT(COT_LOG_CAT_INSTRUCTIONS, "Custom opcode %d out of bounds", index);
         return;
@@ -51,7 +52,7 @@ __attribute((used)) void DispatchCustomInstruction(int index, uint16_t* args) {
 
     struct custom_instruction* instruction = &CUSTOM_INSTRUCTIONS[index];
     COT_LOGFMT(COT_LOG_CAT_INSTRUCTIONS, "Running custom instruction '%s' with %d arguments (opcode %d, index %d)", instruction->name, instruction->n_params, FIRST_CUSTOM_OPCODE + index, index);
-    instruction->handler(args);
+    instruction->handler(routine, args);
 }
 
 #endif

--- a/src/ground_instructions.c
+++ b/src/ground_instructions.c
@@ -15,7 +15,7 @@
 // - `height`: dialogue box height
 // - `screen`: 0 = bottom screen, 1 = top screen
 // - `frame`: 0xFD = default, 0xFA = invisible, ...
-void OpSetDialogueBoxAttributes(uint16_t* args) {
+void OpSetDialogueBoxAttributes(struct script_routine* routine, uint16_t* args) {
     int x = ScriptParamToInt(args[0]);
     int y = ScriptParamToInt(args[1]);
     int width = ScriptParamToInt(args[2]);
@@ -33,11 +33,11 @@ void OpSetDialogueBoxAttributes(uint16_t* args) {
     COT_LOGFMT(COT_LOG_CAT_INSTRUCTIONS, "Setting dialogue box attributes: x=%d, y=%d, width=%d, height=%d, screen=%d, frame=%d", x, y, width, height, screen, frame);
 }
 
-// Saves the set of held/pressed buttons into $EVENT_LOCAL as a bitfield.
+// Returns the set of held/pressed buttons as a bitfield.
 //
 // # Arguments
 // - `mode`: 0 = pressed buttons, 1 = held buttons
-void OpCheckInputStatus(uint16_t* args) {
+void OpCheckInputStatus(struct script_routine* routine, uint16_t* args) {
     int mode = ScriptParamToInt(args[0]);
 
     int buttons = 0;
@@ -46,7 +46,7 @@ void OpCheckInputStatus(uint16_t* args) {
     } else {
         GetHeldButtons(0, (undefined*) &buttons);
     }
-    SaveScriptVariableValue(NULL, VAR_EVENT_LOCAL, buttons);
+    routine->states[0].ssb_info[0].next_opcode_addr = ScriptCaseProcess(routine, buttons);
 }
 
 // Add your custom instructions to the list below.

--- a/src/menus.c
+++ b/src/menus.c
@@ -6,12 +6,6 @@
 
 #if CUSTOM_SCRIPT_MENUS
 
-// The following functions aren't in pmdsky-debug yet, so we have to declare them
-// here and add their offsets in "symbols/custom_[region].ld".
-extern void InitGroundMonsterBaseStats(struct ground_monster* ground_monster);
-extern void InitGroundMonsterStatsAndMoveset(struct ground_monster* ground_monster, int level, bool flag);
-extern void SetupKeyboard(int index, char* buffer1, char* buffer2);
-
 // The "entry" function called for every single option of the Advanced Menu created by CreateRecruitAnyMonsterMenu. The resulting buffer will be used as the option string for the given `option_id`.
 // In this instance, the goal is to make a menu that consists of every Pokémon, so every option will need to show each Pokémon's name!
 // `option_id` starts at 0, but the first Pokémon (Bulbasaur) starts at 1, hence the +1.
@@ -151,8 +145,8 @@ bool UpdateRecruitAnyMonsterMenu(void) {
                 new_recruit->joined_at.val = DUNGEON_TEST_DUNGEON;
                 new_recruit->joined_at_floor = 1;
                 StrncpyName(new_recruit->name, GetNameString(monster_id), 10);
-                InitGroundMonsterBaseStats(new_recruit);
-                InitGroundMonsterStatsAndMoveset(new_recruit, 1, false);
+                SetBaseStatsMovesGroundMonster(new_recruit);
+                ApplyLevelUpBoostsToGroundMonster(new_recruit, 1, false);
                 SetPokemonJoined(monster_id);
                 GLOBAL_MENU_INFO.return_val = index;
             }
@@ -171,7 +165,7 @@ bool UpdateRecruitAnyMonsterMenu(void) {
 // The initial menu function called to show a keyboard prompt for the player to type in a string.
 // This is intended to be used by a variety of menus.
 void CreateSimpleKeyboardMenu(void) {
-    SetupKeyboard(GLOBAL_MENU_INFO.id, NULL, NULL);
+    SetupAndShowKeyboard(GLOBAL_MENU_INFO.id, NULL, NULL);
 }
 
 // The menu function called repeatedly to check if the player has finished entering a string.

--- a/src/special_processes.c
+++ b/src/special_processes.c
@@ -1,14 +1,10 @@
 #include <pmdsky.h>
 #include <cot.h>
 
-// This function isn't in pmdsky-debug yet, so we have to declare it
-// here and add its offset in "symbols/custom_[region].ld".
-extern void ChangeGlobalBorderColor(int color_type);
-
 // Special process 100: Change border color
 // Based on https://github.com/SkyTemple/eos-move-effects/blob/master/example/process/set_frame_color.asm
 static int SpChangeBorderColor(short arg1) {
-  ChangeGlobalBorderColor(arg1);
+  SetBothScreensWindowsColor(arg1);
   return 0;
 }
 

--- a/symbols/custom_EU.ld
+++ b/symbols/custom_EU.ld
@@ -18,10 +18,6 @@ ApplyItemEffectJumpAddr = 0x0231D574;
 /* Add your own symbols here... */
 
 /* !file arm9 */
-ChangeGlobalBorderColor = 0x02027D74;
-InitGroundMonsterBaseStats = 0x02053278;
-InitGroundMonsterStatsAndMoveset = 0x02054844;
-SetupKeyboard = 0x02036AA8;
 ShowKeyboardTypeCase3 = 0x02036C10;
 ShowKeyboardTypeDefaultCase = 0x02036D3C;
 ShowKeyboardReturn = 0x02036FA8;

--- a/symbols/custom_JP.ld
+++ b/symbols/custom_JP.ld
@@ -18,10 +18,6 @@ ApplyItemEffectJumpAddr = 0x0231DFE0;
 /* Add your own symbols here... */
 
 /* !file arm9 */
-ChangeGlobalBorderColor = 0x02027DE0;
-InitGroundMonsterBaseStats = 0x02053234;
-InitGroundMonsterStatsAndMoveset = 0x02054800;
-SetupKeyboard = 0x02036ACC;
 ShowKeyboardTypeCase3 = 0x02036C34;
 ShowKeyboardTypeDefaultCase = 0x02036D54;
 ShowKeyboardReturn = 0x02036FC0;

--- a/symbols/custom_NA.ld
+++ b/symbols/custom_NA.ld
@@ -18,10 +18,6 @@ ApplyItemEffectJumpAddr = 0x0231CB14;
 /* Add your own symbols here... */
 
 /* !file arm9 */
-ChangeGlobalBorderColor = 0x02027A80;
-InitGroundMonsterBaseStats = 0x02052EFC;
-InitGroundMonsterStatsAndMoveset = 0x020544C8;
-SetupKeyboard = 0x020367B4;
 ShowKeyboardTypeCase3 = 0x02036914;
 ShowKeyboardTypeDefaultCase = 0x02036A40;
 ShowKeyboardReturn = 0x02036CAC;


### PR DESCRIPTION
- Implements passing a `script_routine` pointer into custom ground instructions, due to recent ground mode documentation. In practice, this allows for custom ground instructions to:
  - Manipulate any live entity (actor/object/performer) that uses the opcode
  - Manipulate the various fields of a script routine that is currently being executed
  - Return any value that's caught with a switch-statement in ExplorerScript
- Edits the custom ground instruction `CheckInputStatus` to return a value instead of saving the buttons bitfield to $EVENT_LOCAL
- Removes unnecessarily-defined symbols that have since been documented
- Updates README.md
- Updates pmdsky-debug to the latest revision