### PR TITLE
Compatibility with ExtractMoveCode and ExtractItemCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please note that custom move effects are currently *not* handled by the *Metrono
 
 #### Compatiblity with existing patches
 
-If a move/item is given an effect in c-of-time, that will take priority over any ASM effect given to it through ExtractMoveCode or ExtractItemCode.
+If a move/item is given an effect in c-of-time, that will take priority over any ASM effect given to it through ExtractMoveCode or ExtractItemCode. Specifically, the game will only try to run a vanilla/ASM effect for a move/item if `CustomApplyMoveEffect`/`CustomApplyItemEffect` returns false. Other than that, ExtractMoveCode, ExtractItemCode, and ExtractSPCode are fully compatible with c-of-time.
 
 ### Custom script engine instructions
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Please note that custom move effects are currently *not* handled by the *Metrono
 
 #### Compatiblity with existing patches
 
-**Note: ROMs patched with c-of-time currently experience crashes with the `ExtractItemCode` and `ExtractMoveCode` patch.**
+**Note: ROMs patched with c-of-time currently experience crashes with the `ExtractItemCode` patch.**
 
-You can work around the crash by removing `.open "overlay29.bin", overlay29_start` and all following lines in `patches/internal.asm`.
-However, doing so will cause custom effects written in C to have no effect.
+You can work around the crash by removing `.org ApplyItemEffectHookAddr` and `b cotInternalTrampolineApplyItemEffect` in `patches/internal.asm`.
+However, doing so will cause custom item effects written in C to have no effect.
 
 Please reach out to us [on Discord](https://discord.gg/skytemple) for potential workarounds if you need to use the aforementioned patches while also adding effects via c-of-time.
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,7 @@ Please note that custom move effects are currently *not* handled by the *Metrono
 
 #### Compatiblity with existing patches
 
-**Note: ROMs patched with c-of-time currently experience crashes with the `ExtractItemCode` patch.**
-
-You can work around the crash by removing `.org ApplyItemEffectHookAddr` and `b cotInternalTrampolineApplyItemEffect` in `patches/internal.asm`.
-However, doing so will cause custom item effects written in C to have no effect.
-
-Please reach out to us [on Discord](https://discord.gg/skytemple) for potential workarounds if you need to use the aforementioned patches while also adding effects via c-of-time.
+If a move/item is given an effect in c-of-time, that will take priority over any ASM effect given to it through ExtractMoveCode or ExtractItemCode.
 
 ### Custom script engine instructions
 

--- a/patches/internal.asm
+++ b/patches/internal.asm
@@ -43,8 +43,8 @@
   .org ApplyItemEffectHookAddr
     bl cotInternalTrampolineApplyItemEffect
   .org ApplyMoveEffectHookAddr
-    sub sp,sp,#0xC   // allocate stack space for data param of cotInternalDispatchApplyMoveEffect
-    str r6,[sp]      // data->move_id
-    str r7,[sp,#0x4] // data->item_id
+    nop       // Normally there would be a bne here that skips the next three lines; we don't want to do that, because we want to always run the hook. We still use the condition flags to skip the function that needs to be skipped in trampolines.s.
+    mov r0,r9 // UNCHANGED
+    mov r1,r4 // UNCHANGED
     bl  cotInternalTrampolineApplyMoveEffect
 .close

--- a/patches/internal.asm
+++ b/patches/internal.asm
@@ -43,5 +43,8 @@
   .org ApplyItemEffectHookAddr
     b cotInternalTrampolineApplyItemEffect
   .org ApplyMoveEffectHookAddr
-    b cotInternalTrampolineApplyMoveEffect
+    sub sp,sp,#0xC   // allocate stack space for data param of cotInternalDispatchApplyMoveEffect
+    str r6,[sp]      // data->move_id
+    str r7,[sp,#0x4] // data->item_id
+    bl cotInternalTrampolineApplyMoveEffect
 .close

--- a/patches/internal.asm
+++ b/patches/internal.asm
@@ -41,10 +41,10 @@
 
 .open "overlay29.bin", overlay29_start
   .org ApplyItemEffectHookAddr
-    b cotInternalTrampolineApplyItemEffect
+    bl cotInternalTrampolineApplyItemEffect
   .org ApplyMoveEffectHookAddr
     sub sp,sp,#0xC   // allocate stack space for data param of cotInternalDispatchApplyMoveEffect
     str r6,[sp]      // data->move_id
     str r7,[sp,#0x4] // data->item_id
-    bl cotInternalTrampolineApplyMoveEffect
+    bl  cotInternalTrampolineApplyMoveEffect
 .close

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -10,6 +10,7 @@ import platform
 import tempfile
 
 OVERLAY_EXTRA = 36
+OVERLAY_DUNGEON = 29
 
 region = sys.argv[1]
 rom_path = sys.argv[2]
@@ -20,6 +21,14 @@ overlay_symbols_lookup = {} # Key = symbol_name: string, value = offset: int
 
 rom = ndspy.rom.NintendoDSRom.fromFile(rom_path)
 overlays = rom.loadArm9Overlays()
+
+# Migration data for old CoT move/item effect hooks applied before https://github.com/SkyTemple/c-of-time/pull/268.
+EMC_OLD_HOOK_ADDR = { "EU": 0x023302E4, "NA": 0x0232F8A4, "JP": 0x02330C98 }
+EIC_OLD_HOOK_ADDR = { "EU": 0x0231C438, "NA": 0x0231B9D8, "JP": 0x0231CEA4 }
+EMC_MIGRATION_PATCHED_BYTES = 0xE59FB0FC
+EMC_MIGRATION_VANILLA_BYTES = 0xE3A01001
+EIC_MIGRATION_PATCHED_BYTES = 0x0A000029
+EIC_MIGRATION_VANILLA_BYTES = 0xE3500000
 
 def load_overlay_symbols():
   process = Popen(["arm-none-eabi-nm", overlay_elf_path], stdout=PIPE)
@@ -112,7 +121,44 @@ def apply_overlay():
     if readline>0:
       readline -= 1
 
+def migrate_eimc_hooks():
+  move_addr = EMC_OLD_HOOK_ADDR.get(region)
+  item_addr = EIC_OLD_HOOK_ADDR.get(region)
+  if move_addr is None or item_addr is None:
+    # Unknown region, skip migration
+    return
+
+  overlay = overlays[OVERLAY_DUNGEON]
+  data = bytearray(rom.files[overlay.fileID])
+  ram_base = overlay.ramAddress
+
+  emc_applied = rom.filenames.idOf("BALANCE/waza_cd.bin") is not None
+  eic_applied = rom.filenames.idOf("BALANCE/item_cd.bin") is not None
+
+  move_expected = EMC_MIGRATION_PATCHED_BYTES if emc_applied else EMC_MIGRATION_VANILLA_BYTES
+  item_expected = EIC_MIGRATION_PATCHED_BYTES if eic_applied else EIC_MIGRATION_VANILLA_BYTES
+
+  move_offset = move_addr - ram_base
+  item_offset = item_addr - ram_base
+  move_current = int.from_bytes(data[move_offset:move_offset + 4], "little")
+  item_current = int.from_bytes(data[item_offset:item_offset + 4], "little")
+
+  changed = False
+  if move_current != move_expected:
+    print(f"!!! Patching old CoT move effect hook detected at {hex(move_addr)}")
+    data[move_offset:move_offset + 4] = move_expected.to_bytes(4, "little")
+    changed = True
+  if item_current != item_expected:
+    print(f"!!! Patching old CoT item effect hook detected at {hex(item_addr)}")
+    data[item_offset:item_offset + 4] = item_expected.to_bytes(4, "little")
+    changed = True
+
+  if changed:
+    rom.files[overlay.fileID] = bytes(data)
+
 def apply_binary_patches():
+  migrate_eimc_hooks() # Fixup old CoT move/item effect hooks
+
   if not os.path.exists("build/binaries"):
     os.mkdir("build/binaries")
 

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -20,8 +20,8 @@ cotInternalTrampolineApplyItemEffect:
   pop     {lr}
   cmp     r0,#0 // Was the effect handled?
   ldreqsh r0,[r6,#0x4] // original instruction
-  bxeq    lr
-  b       ApplyItemEffectJumpAddr
+  bxeq    lr                      // If not, return to vanilla flow; let vanilla code / ExtractItemCode handle the Item.
+  b       ApplyItemEffectJumpAddr // Otherwise, we're done! Jump towards the end of ApplyItemEffect after the item handling code for finalization
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -25,9 +25,9 @@ cotInternalTrampolineApplyItemEffect:
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:
+  bleq  UpdateShopkeeperModeAfterAttack // Original instruction from vanilla code; condition flags were set before our hook
   mov   r10,#0                          // Redundancy; only really matters if the user forgets to assign out_dealt_damage in CustomApplyMoveEffect.
   push  {r6,r7,r10,lr}                  // Create move_effect_input struct from move_id, item_id, and out_dealt_damage. Save lr for later so we can return from where we hooked.
-  bleq  UpdateShopkeeperModeAfterAttack // Condition is "GetEntityMoveTargetAndRange(attacker,move,NULL) & 0xF == 0" from vanilla code; condition flags were set by tst r0,#0
   mov   r0,sp                           // data (put in the stack by the previous push)
   mov   r1,r9                           // user
   mov   r2,r4                           // target

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -11,29 +11,17 @@ cotInternalTrampolineScriptSpecialProcessCall:
 
 .align 4
 cotInternalTrampolineApplyItemEffect:
-  // Backup registers
-  push {r0-r9, r11, r12}
-
-  // Call the hook function
-  mov r0, r8
-  mov r1, r7
-  mov r2, r6
-  mov r3, r9
-  bl cotInternalDispatchApplyItemEffect
-  // Check if true was returned
-  cmp r0, #1
-
-  // Load saved registers
-  popeq {r0-r9, r11, r12}
-
-  // If yes, exit the original function
-  beq ApplyItemEffectJumpAddr
-
-  pop {r0-r9, r11, r12}
-
-  // Restore the instruction that was replaced with the patch and call the original function
-  cmp r0, #0
-  b ApplyItemEffectHookAddr+4
+  push    {lr}
+  mov     r0,r8 // user
+  mov     r1,r7 // target
+  mov     r2,r6 // item
+  mov     r3,r9 // is_thrown
+  bl      cotInternalDispatchApplyItemEffect
+  pop     {lr}
+  cmp     r0,#0 // Was the effect handled?
+  ldreqsh r0,[r6,#0x4] // original instruction
+  bxeq    lr
+  b       ApplyItemEffectJumpAddr
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -37,42 +37,23 @@ cotInternalTrampolineApplyItemEffect:
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:
-  // Backup registers
-  push {r0-r9, r11, r12}
-
-  // Setup move_effect_input struct
-  ldr r10, =move_effect_input
-  str r6, [r10] // move_id
-  str r7, [r10, #0x4] // item_id
-  mov r0, #0
-  str r0, [r10, #0x8] // out_dealt_damage
-
-  // Call the hook function
-  mov r0, r10
-  mov r1, r9
-  mov r2, r4
-  mov r3, r8
-  bl cotInternalDispatchApplyMoveEffect
-
-  // Check if true was returned
-  cmp r0, #1
-
-  // Load saved registers
-  popeq {r0-r9, r11, r12}
-  ldreq r10, =move_effect_input_out_dealt_damage
-
-  // If yes, exit the original function
-  beq ApplyMoveEffectJumpAddr
-
-  pop {r0-r9, r11, r12}
-
-  // Restore the instruction that was replaced with the patch and call the original function
-  mov r1, #0x1
-  b ApplyMoveEffectHookAddr+4
-
-.align 4
-move_effect_input:
-  .word 0
-  .word 0
-move_effect_input_out_dealt_damage:
-  .word 0
+  push  {lr}
+  bne   TryHandleMove
+  mov   r0,r9
+  mov   r1,r4
+  bl    UpdateShopkeeperModeAfterAttack
+  TryHandleMove:
+  // Stack was already configured to set up data before, EXCEPT out_dealt_damage, which we init to 0 now.
+  // Initializing this may be redundant; it should only really matter if you forget to assign out_dealt_damage for a handled move in CustomApplyMoveEffect. If you're an optimization freak like I am, you can comment out the next 2 lines.
+  mov   r0,#0
+  str   r0,[sp,#0xC]            // Would be #0x8, but SP decreased by 4 when we pushed lr, so we need to counteract that by adding 4 here
+  add   r0,sp,#4                // data (would be mov r0,sp if not for the same point mentioned above)
+  mov   r1,r9                   // user
+  mov   r2,r4                   // target
+  mov   r3,r8                   // move
+  bl    cotInternalDispatchApplyMoveEffect
+  pop   {r1,r2,r3,r10}          // Get original LR (into r1) so we can return to vanilla flow if needed, put data->out_dealt_damage in r10, and reset SP to where it was before we hooked. (We don't do anything with r1/r2, we just need to pop 4 registers so r10 comes from the correct place and the SP is increased by 0x10.) We use r1 instead of lr, because using actual lr will try to pop that LAST.
+  cmp   r0,#0                   // Was the move handled?
+  bxeq  r1                      // If not, return to vanilla flow
+  cmp   r10,#0                  // Instruction right before return point (We don't jump straight to this instruction due for ExtractMoveCode compatibility)
+  b     ApplyMoveEffectJumpAddr // Otherwise, we're done!

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -25,23 +25,16 @@ cotInternalTrampolineApplyItemEffect:
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:
-  push  {lr}
-  bne   TryHandleMove
-  mov   r0,r9
-  mov   r1,r4
-  bl    UpdateShopkeeperModeAfterAttack
-  TryHandleMove:
-  // Stack was already configured to set up data before, EXCEPT out_dealt_damage, which we init to 0 now.
-  // Initializing this may be redundant; it should only really matter if you forget to assign out_dealt_damage for a handled move in CustomApplyMoveEffect. If you're an optimization freak like I am, you can comment out the next 2 lines.
-  mov   r0,#0
-  str   r0,[sp,#0xC]            // Would be #0x8, but SP decreased by 4 when we pushed lr, so we need to counteract that by adding 4 here
-  add   r0,sp,#4                // data (would be mov r0,sp if not for the same point mentioned above)
-  mov   r1,r9                   // user
-  mov   r2,r4                   // target
-  mov   r3,r8                   // move
+  mov   r10,#0                          // Redundancy; only really matters if the user forgets to assign out_dealt_damage in CustomApplyMoveEffect.
+  push  {r6,r7,r10,lr}                  // Create move_effect_input struct from move_id, item_id, and out_dealt_damage. Save lr for later so we can return from where we hooked.
+  bleq  UpdateShopkeeperModeAfterAttack // Condition is "GetEntityMoveTargetAndRange(attacker,move,NULL) & 0xF == 0" from vanilla code; condition flags were set by tst r0,#0
+  mov   r0,sp                           // data (put in the stack by the previous push)
+  mov   r1,r9                           // user
+  mov   r2,r4                           // target
+  mov   r3,r8                           // move
   bl    cotInternalDispatchApplyMoveEffect
-  pop   {r1,r2,r3,r10}          // Get original LR (into r1) so we can return to vanilla flow if needed, put data->out_dealt_damage in r10, and reset SP to where it was before we hooked. (We don't do anything with r1/r2, we just need to pop 4 registers so r10 comes from the correct place and the SP is increased by 0x10.) We use r1 instead of lr, because using actual lr will try to pop that LAST.
-  cmp   r0,#0                   // Was the move handled?
-  bxeq  r1                      // If not, return to vanilla flow
-  cmp   r10,#0                  // Instruction right before return point (We don't jump straight to this instruction due for ExtractMoveCode compatibility)
-  b     ApplyMoveEffectJumpAddr // Otherwise, we're done!
+  pop   {r6,r7,r10,lr}                  // Put move_effect_input back into r6, r7, and r10. Restore lr to what it was coming in so we can return from where we hooked.
+  cmp   r0,#0                           // Was the move handled?
+  bxeq  lr                              // If not, return to vanilla flow; let vanilla code / ExtractMoveCode handle the move.
+  cmp   r10,#0                          // Instruction right before return point (We don't jump straight to this instruction due for ExtractMoveCode compatibility)
+  b     ApplyMoveEffectJumpAddr         // Otherwise, we're done! Jump towards the end of ExecuteMoveEffect after the move handling code for finalization

--- a/src/move_effects.c
+++ b/src/move_effects.c
@@ -1,6 +1,8 @@
 #include <pmdsky.h>
 #include <cot.h>
 
+// A move effect function should return a bool for whether or not the move succeeded; this is used to determine whether Wary Fighter will activate.
+
 // Implements the "Body Press" move
 // Based on https://github.com/Adex-8x/EoS-ASM-Effects/blob/main/moves/gen8/body_press.asm
 // Deals damage based on the user's defense instead of attack stat

--- a/symbols/custom_EU.ld
+++ b/symbols/custom_EU.ld
@@ -12,7 +12,7 @@ IS_BASE_GAME_MENU_FINISHED = 0x023257DC;
 ApplyMoveEffect = 0x0232F2A4;
 ApplyMoveEffectHookAddr = 0x023302D0;
 ApplyMoveEffectJumpAddr = 0x02333110;
-ApplyItemEffectHookAddr = 0x0231C438;
+ApplyItemEffectHookAddr = 0x0231C408;
 ApplyItemEffectJumpAddr = 0x0231D574;
 
 /* Add your own symbols here... */

--- a/symbols/custom_EU.ld
+++ b/symbols/custom_EU.ld
@@ -10,8 +10,8 @@ IS_BASE_GAME_MENU_FINISHED = 0x023257DC;
 
 /* !file overlay29 */
 ApplyMoveEffect = 0x0232F2A4;
-ApplyMoveEffectHookAddr = 0x023302E4;
-ApplyMoveEffectJumpAddr = 0x0233310C;
+ApplyMoveEffectHookAddr = 0x023302D0;
+ApplyMoveEffectJumpAddr = 0x02333110;
 ApplyItemEffectHookAddr = 0x0231C438;
 ApplyItemEffectJumpAddr = 0x0231D574;
 

--- a/symbols/custom_JP.ld
+++ b/symbols/custom_JP.ld
@@ -12,7 +12,7 @@ IS_BASE_GAME_MENU_FINISHED = 0x023261FC;
 ApplyMoveEffect = 0x0232FC60;
 ApplyMoveEffectHookAddr = 0x02330C84;
 ApplyMoveEffectJumpAddr = 0x02333AC4;
-ApplyItemEffectHookAddr = 0x0231CEA4;
+ApplyItemEffectHookAddr = 0x0231CE74;
 ApplyItemEffectJumpAddr = 0x0231DFE0;
 
 /* Add your own symbols here... */

--- a/symbols/custom_JP.ld
+++ b/symbols/custom_JP.ld
@@ -10,8 +10,8 @@ IS_BASE_GAME_MENU_FINISHED = 0x023261FC;
 
 /* !file overlay29 */
 ApplyMoveEffect = 0x0232FC60;
-ApplyMoveEffectHookAddr = 0x02330C98;
-ApplyMoveEffectJumpAddr = 0x02333AC0;
+ApplyMoveEffectHookAddr = 0x02330C84;
+ApplyMoveEffectJumpAddr = 0x02333AC4;
 ApplyItemEffectHookAddr = 0x0231CEA4;
 ApplyItemEffectJumpAddr = 0x0231DFE0;
 

--- a/symbols/custom_NA.ld
+++ b/symbols/custom_NA.ld
@@ -10,8 +10,8 @@ IS_BASE_GAME_MENU_FINISHED = 0x02324C9C;
 
 /* !file overlay29 */
 ApplyMoveEffect = 0x0232E864;
-ApplyMoveEffectHookAddr = 0x0232F8A4;
-ApplyMoveEffectJumpAddr = 0x023326CC;
+ApplyMoveEffectHookAddr = 0x0232F890;
+ApplyMoveEffectJumpAddr = 0x023326D0;
 ApplyItemEffectHookAddr = 0x0231B9D8;
 ApplyItemEffectJumpAddr = 0x0231CB14;
 

--- a/symbols/custom_NA.ld
+++ b/symbols/custom_NA.ld
@@ -12,7 +12,7 @@ IS_BASE_GAME_MENU_FINISHED = 0x02324C9C;
 ApplyMoveEffect = 0x0232E864;
 ApplyMoveEffectHookAddr = 0x0232F890;
 ApplyMoveEffectJumpAddr = 0x023326D0;
-ApplyItemEffectHookAddr = 0x0231B9D8;
+ApplyItemEffectHookAddr = 0x0231B9A8;
 ApplyItemEffectJumpAddr = 0x0231CB14;
 
 /* Add your own symbols here... */


### PR DESCRIPTION
*For brevity, this pull request will abbreviate ExtractItemCode as EIC, ExtractMoveCode as EMC, and "ExtractItemCode and/or ExtractMoveCode" as EIMC. (And c-of-time will be abbreviated as CoT, but you already knew what that meant.)*

*All offsets are EU in overlay 29. The relevant functions contain no significant differences across different releases.*

# The problem (context)
From the current [c-of-time README](https://github.com/SkyTemple/c-of-time/blob/f8155e3eec97d31792fe13e64935d79270108d4f/README.md?plain=1#L62):
> **ROMs patched with c-of-time currently experience crashes with the `ExtractItemCode` and `ExtractMoveCode` patch.**

This is obviously not great. Currently, if one developer for a hack wishes to use CoT for move/item effects for a hack, all other authors who wish to write move/item effects must *also* set up CoT, which not everybody wants to do.

With both c-of-time and EIMC applied, the game will crash whenever a move/item effect is executed, within `ExecuteMoveEffect` and `ApplyItemEffect` respectively. If you look at the respective starting points for each patch, the overlap is clear:
* [EMC](https://github.com/SkyTemple/skytemple-files/blob/386f8988d12f7a2568b857ce9870cdaf16962eb1/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_move_code/eu/patch_overlay10.asm#L8): 0x23302E0
* [CoT move effects](https://github.com/SkyTemple/c-of-time/blob/f8155e3eec97d31792fe13e64935d79270108d4f/symbols/custom_EU.ld#L13): 0x23302E4 (4 bytes after EMC's start)
* [EIC](https://github.com/SkyTemple/skytemple-files/blob/386f8988d12f7a2568b857ce9870cdaf16962eb1/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_item_code/eu/patch.asm#L8): 0x231C40C
* [CoT item effects](https://github.com/SkyTemple/c-of-time/blob/f8155e3eec97d31792fe13e64935d79270108d4f/symbols/custom_EU.ld#L15): 0x231C438 (0x2C bytes after EIC's start)

Applying EIMC after c-of-time erases CoT's hooks, causing them to have no effect, but applying CoT *after* EIMC overwrites EIMC code with c-of-time hooks, which obviously breaks things. (So, a simple patch overlap.)

Workarounds have been written before, such as Marius' custom hook for move effects, but this just flips who will encounter problems, as Marius' custom hook *requires* that EMC be applied and will crash without it. While this is certainly an improvement, it's not a universal solution, nor does it help with item effects.

**TL;DR**: Patch overlaps bad, let's fix them.

# The solution ("universal hooks"):
As with any patch overlap, this really just boils down to rewriting the hook so it doesn't touch any areas the conflicting patch does. My goal was to write hooks for c-of-time move/item effects that work *regardless* of whether or not EIMC are applied: "universal hooks". The process differed a bit for items and moves respectively, so let's go through them one at a time:
## Universal item effects hook
This one's pretty simple: move the hook from 0x231C438 to 0x0231C408, immediately before EIC's modified code.
* Changed the original instruction in the trampoline accordingly (from `cmp r0,#0x0` to `ldrsh r0.[r6,#0x4]`)
* Optimize the stack usage, we do NOT need to be pushing all those registers.
* Use a `bl`/`bx lr` hook instead of `b`/`b HookAddr+4`; proper `bl` function calls are easier to debug.

This earlier hook will also work for *all* items; the current hook only runs for item IDs less than or equal to 0xB6.
### Universal item effect hook tests:
**Using CoT items and non-CoT items without EIC (making sure I didn't break anything that was already working)**:

https://github.com/user-attachments/assets/426e9784-6fa1-4b6c-ac78-a28ca5f6a48d

**Using CoT items and non-CoT items (ASM items) *with* EIC (testing EIC compatibility with the hook)**:

https://github.com/user-attachments/assets/8f16a009-3704-43bb-9674-e615a7519ae3

## Universal move effect hooks
This one's a little more complicated, mainly to fix some existing mistakes and also in my unending pursuit of optimization. I could really have put the hook anywhere between 0x23302D0 and 0x23302DC as long as I overwrote 0x23302D0's `bne` to ensure the custom code would always run, but I overwrite the entire instruction block with code that would need to be run regardless of if that branch condition was met and would otherwise need to be stored in the trampoline; the original instructions are run at the start of the trampoline if they need to be run. Optimization, yay!

Beyond that:
* Use the stack for `move_effect_input` instead of creating a buffer; there really wasn't any reason this needed to have its own buffer.
* Optimize stack usage; we don't need to be pushing all those registers, *and* in a single `pop` instruction, we're actually able to:
  * Restore sp to what it needs to be
  * Get `move_effect_input_out_dealt_damage` in r10
    * This is actually bugged in current; it puts a *pointer* to `move_effect_input_out_dealt_damage` instead of the *value* of `move_effect_input_out_dealt_damage`, meaning it would always behave as if it were true even if a move failed. As such, Wary Fighter would never activate on a CoT move. This new implementation fixes that. You can see this proper behavior in the below test videos, where Wary Fighter properly triggers if a move returns false.
  * Prepare for return by restoring the original value of lr to a register (we use r1 instead of lr for ordering reasons; this doesn't really matter.)
* Use a `bl`/`bx lr` hook instead of `b`/`b HookAddr+4`; same reason as in item effects.

### Universal moves effect hook tests:
**Using CoT moves and non-CoT moves without EMC (making sure I didn't break anything that was already working)**:

https://github.com/user-attachments/assets/05e29566-1adc-4d35-ac43-21941bd8342e

**Using CoT moves and non-CoT moves (ASM moves) *with* EMC (testing EMC compatibility with the hook)**:

https://github.com/user-attachments/assets/c1432ca1-607f-4fe5-8378-94c99a18deeb

# Other regions
As mentioned at the start, the relevant functions are mostly identical between releases. I've done brief tests of move effects on NA, and I have NOT tested on JP, but I believe it should be fine.

Closes #262.