### PR TITLE
Allow multiple custom .ld files, add simple submodule system 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ CFLAGS  +=  $(EXTRA_CFLAGS)
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS	:=	-g $(ARCH)
+CUSTOM_LDS := $(wildcard $(CURDIR)/../symbols/custom_$(REGION).ld) \
+              $(wildcard $(CURDIR)/../symbols/custom_$(REGION)_*.ld)
 LDFLAGS	=	-T $(CURDIR)/../symbols/generated_$(REGION).ld \
-			-T $(CURDIR)/../symbols/custom_$(REGION).ld -T $(CURDIR)/../linker.ld \
+			$(foreach ld,$(CUSTOM_LDS),-T $(ld)) -T $(CURDIR)/../linker.ld \
 			-g $(ARCH) -Wl,-Map,$(notdir $*.map) -Xlinker -no-enum-size-warning -nostdlib  -Xlinker --no-check-sections
 
 #---------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ TARGET		:=	out
 BUILD		:=	build
 SOURCES		:=	src src/cot
 INCLUDES	:=	include pmdsky-debug/headers
+
+MODULES		:=	$(wildcard modules/*)
+SOURCES		+=	$(foreach m,$(MODULES),$(wildcard $(m)/src))
+INCLUDES	+=	$(foreach m,$(MODULES),$(wildcard $(m)/include))
 OPT_LEVEL := -O2
 
 # Change to "RELEASE_CONFIG := -DNDEBUG" for release builds without asserts and logs
@@ -81,7 +85,9 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS	:=	-g $(ARCH)
 CUSTOM_LDS := $(wildcard $(CURDIR)/../symbols/custom_$(REGION).ld) \
-              $(wildcard $(CURDIR)/../symbols/custom_$(REGION)_*.ld)
+              $(wildcard $(CURDIR)/../symbols/custom_$(REGION)_*.ld) \
+              $(wildcard $(CURDIR)/../modules/*/symbols/custom_$(REGION).ld) \
+              $(wildcard $(CURDIR)/../modules/*/symbols/custom_$(REGION)_*.ld)
 LDFLAGS	=	-T $(CURDIR)/../symbols/generated_$(REGION).ld \
 			$(foreach ld,$(CUSTOM_LDS),-T $(ld)) -T $(CURDIR)/../linker.ld \
 			-g $(ARCH) -Wl,-Map,$(notdir $*.map) -Xlinker -no-enum-size-warning -nostdlib  -Xlinker --no-check-sections

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Subtract the amount of additional bytes you want to allocate from `ORIGIN` and a
 ### Optimizing for size
 You can also change the compiler flags to optimize for size instead of speed. To do so, set `OPT_LEVEL := Os` in `Makefile`. Effectiveness varies per project.
 
+## Submodules
+
+You can add external c-of-time compatible libraries as Git submodules:
+
+```bash
+git submodule add https://github.com/user/module-name modules/module-name
+```
+
+**Caveat:** File names currently must be unique across all modules and code in the main repository.
+
 ## Licensing
 - Build scripts (everything under the `scripts` directory) are licensed under GPLv3. Review the file `LICENSE_GPLv3` for more information.
 - All other code is licensed under MIT. Review the file `LICENSE_MIT` for more information.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ then clean the build with `make clean`.
 ## Adding custom symbols
 If you've found symbols that are currently missing, consider contributing them to [pmdsky-debug](https://github.com/UsernameFodder/pmdsky-debug). You can find instructions in the repository's [contribution docs](https://github.com/UsernameFodder/pmdsky-debug/blob/master/docs/contributing.md).
 
-For quick testing, you can also add symbols to `symbols/custom_[region].ld` (`symbols/generated_[region].ld` is auto-generated and should not be modified). You need to specify the file each symbol belongs to in comments:
+For quick testing, you can also add symbols to `symbols/custom_[region].ld` (`symbols/generated_[region].ld` is auto-generated and should not be modified). You can also add additional linker scripts that match `symbols/custom_[region]_*.ld`. You need to specify the file each symbol belongs to in comments:
 
 ```
 /* !file arm9 */

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -143,7 +143,7 @@ def apply_binary_patches():
     with open(f"build/binaries/overlay{index}.bin", "wb") as f:
       f.write(rom.files[overlay.fileID])
 
-  for file in glob.glob("patches/*.asm"):
+  for file in glob.glob("patches/*.asm") + glob.glob("modules/*/patches/*.asm"):
     apply_binary_patch(file)
 
   # Apply the main binaries


### PR DESCRIPTION
Adds a simple module system to c-of-time, which can be used to link external libraries.

Example: `git submodule add https://github.com/irdkwia/snd-stream-c modules/snd-stream-c`.
