### PR TITLE
Fix Move Effects For Certain Range Moves

### DIFF
--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -25,9 +25,9 @@ cotInternalTrampolineApplyItemEffect:
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:
+  push  {r6,r7,r10,lr}                  // Create move_effect_input struct from move_id, item_id, and out_dealt_damage. Save lr for later so we can return from where we hooked.
   bleq  UpdateShopkeeperModeAfterAttack // Original instruction from vanilla code; condition flags were set before our hook
   mov   r10,#0                          // Redundancy; only really matters if the user forgets to assign out_dealt_damage in CustomApplyMoveEffect.
-  push  {r6,r7,r10,lr}                  // Create move_effect_input struct from move_id, item_id, and out_dealt_damage. Save lr for later so we can return from where we hooked.
   mov   r0,sp                           // data (put in the stack by the previous push)
   mov   r1,r9                           // user
   mov   r2,r4                           // target

--- a/src/cot/trampolines.s
+++ b/src/cot/trampolines.s
@@ -25,9 +25,9 @@ cotInternalTrampolineApplyItemEffect:
 
 .align 4
 cotInternalTrampolineApplyMoveEffect:
+  mov   r10,#0                          // Redundancy; only really matters if the user forgets to assign out_dealt_damage in CustomApplyMoveEffect.
   push  {r6,r7,r10,lr}                  // Create move_effect_input struct from move_id, item_id, and out_dealt_damage. Save lr for later so we can return from where we hooked.
   bleq  UpdateShopkeeperModeAfterAttack // Original instruction from vanilla code; condition flags were set before our hook
-  mov   r10,#0                          // Redundancy; only really matters if the user forgets to assign out_dealt_damage in CustomApplyMoveEffect.
   mov   r0,sp                           // data (put in the stack by the previous push)
   mov   r1,r9                           // user
   mov   r2,r4                           // target


### PR DESCRIPTION
Conditionally (depending on the range of the move), the current version can overwrite lr before it's preserved with a conditional bleq to UpdateShopkeeperAttackMode. Moved the push to before the call so lr is saved properly.
<img width="1117" height="642" alt="image" src="https://github.com/user-attachments/assets/afa17c6f-b7c2-46ae-90e7-02d815978050" />
