### PR TITLE
Improved Linux install guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /build
-/venv
+/.venv
 
 out.bin
 out.elf

--- a/install_linux.md
+++ b/install_linux.md
@@ -19,35 +19,41 @@ You can install c-of-time on Ubuntu or Debian using the following methods. The s
 
 1. Open the Terminal app in your Applications menu. The exact steps might vary based on your desktop environment.
 2. Run the following command to install the required tools: `sudo apt install build-essential cmake git python3-pip gcc-arm-none-eabi binutils-arm-none-eabi`. You will need to enter your password during the installation.
-3. Install Python dependencies: `pip3 install pyyaml ndspy --break-system-packages`
-4. Compile `armips`:
+3. Compile `armips`:
     1. Run `git clone --recursive https://github.com/Kingcom/armips.git` to download the source code.
     2. Run `cd armips` to enter the directory.
     3. Run this command to compile the project: `mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build .`
     4. Run `sudo cp armips /usr/local/bin` to install `armips`.
     5. Run `cd ../..` to return to the previous directory.
-5. Navigate to the directory where you want to install c-of-time. You can use `cd` to change the directory and `ls` to list the contents of the current directory. For example, if you want to install c-of-time to `/home/YourName/Documents/c-of-time`, run `cd /home/YourName/Documents`.
+4. Navigate to the directory where you want to install c-of-time. You can use `cd` to change the directory and `ls` to list the contents of the current directory. For example, if you want to install c-of-time to `/home/YourName/Documents/c-of-time`, run `cd /home/YourName/Documents`.
     - **Note:** You can also use the file manager to navigate to the directory where you want to install c-of-time. Right-click the name of the directory and select "Open in Terminal".
-6. Download this repository by running `git clone --recursive https://github.com/SkyTemple/c-of-time.git` in the terminal. c-of-time will be downloaded in a folder called `c-of-time` inside the current directory.
-7. Enter the `c-of-time` directory with `cd c-of-time`.
-8. Copy the ROM you have prepared into the `c-of-time` directory and rename it to `rom.nds`. You can open the file manager in the current directory by running `xdg-open .` in the terminal.
+5. Download this repository by running `git clone --recursive https://github.com/SkyTemple/c-of-time.git` in the terminal. c-of-time will be downloaded in a folder called `c-of-time` inside the current directory.
+6. Enter the `c-of-time` directory with `cd c-of-time`.
+7. Copy the ROM you have prepared into the `c-of-time` directory and rename it to `rom.nds`. You can open the file manager in the current directory by running `xdg-open .` in the terminal.
     - **US ROM offsets are used by default.** If you're using a EU or JP ROM, change the `REGION` variable in `Makefile` to `EU` or `JP` accordingly.
-9. Run `make headers` to add aliases and documentation comments to headers for increased compatibility.
-10. Run `make patch` to build the project. The output ROM will be saved as `out.nds` by default.
+8. Create a Python venv and install dependencies: `python3 -m venv .venv && .venv/bin/pip3 install pyyaml ndspy --break-system-packages`
+9. Activate the Python venv with `source .venv/bin/activate` (use `activate.fish` for fish shell or `activate.csh` for C shell.)
+10. Run `make headers` to add aliases and documentation comments to headers for increased compatibility.
+11. Run `make patch` to build the project. The output ROM will be saved as `out.nds` by default.
 
 ## Fedora
 
 1. Open the Terminal app in your Applications menu. The exact steps might vary based on your desktop environment.
 2. Run the following command to install the required tools: `sudo dnf install @development-tools gcc-c++ cmake git python3-pip arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs`. You will need to enter your password during the installation.
-3. You can now continue with the steps 3-10 of the Ubuntu/Debian method above.
+3. You can now continue with the steps 3-11 of the Ubuntu/Debian method above.
 
 ## Arch Linux
 
 1. Open the Terminal app. The exact steps vary based on your desktop environment.
 2. Run the following command to install the required tools: `sudo pacman -Syu base-devel git python python-pip arm-none-eabi-gcc arm-none-eabi-binutils`. You will need to enter your password during the installation.
-3. Install Python dependencies: `pip3 install pyyaml ndspy --break-system-packages`
-4. Install the [armips package](https://aur.archlinux.org/packages/armips) via the Arch User Repository (AUR). Please refer to the [Arch Wiki](https://wiki.archlinux.org/title/Arch_User_Repository) for instructions.
-5. You can now continue with the steps 5-10 of the Ubuntu/Debian method above.
+3. Install the [armips package](https://aur.archlinux.org/packages/armips) via the Arch User Repository (AUR). Please refer to the [Arch Wiki](https://wiki.archlinux.org/title/Arch_User_Repository) for instructions.
+4. You can now continue with the steps 4-11 of the Ubuntu/Debian method above.
+
+## Future builds (all distros)
+
+1. In the Terminal app, `cd` to the `c-of-time` directory.
+2. Activate the Python venv with `source .venv/bin/activate` (use `activate.fish` for fish shell or `activate.csh` for C shell.)
+3. Run `make patch` to rebuild the project.
 
 ## Other methods (advanced)
 

--- a/install_linux.md
+++ b/install_linux.md
@@ -9,11 +9,17 @@ You can install c-of-time on Linux using the following methods. Instructions var
 
 ## Ubuntu/Debian
 
-You can install c-of-time on Ubuntu or Debian using the following methods. The steps detailed in this guide were tested on Ubuntu 22.04.
+You can install c-of-time on Ubuntu or Debian using the following methods. The steps detailed in this guide were tested on Ubuntu 24.04.
+> [!WARNING]
+>
+> Link-time optimization is known to fail on older versions of gcc-arm-none-eabi, such as 10.3.1,
+> the last version published on Ubuntu Universe for Ubuntu 22 (Jammy). As such, Ubuntu 24 or later
+> is recommended, but if using this version is not possible, link-time optimization can be disabled
+> by removing the `-flto` flag from `CFLAGS` in `Makefile` to circumvent the error. 
 
 1. Open the Terminal app in your Applications menu. The exact steps might vary based on your desktop environment.
-2. Run the following command to install the required tools: `sudo apt install build-essential cmake python3-pip gcc-arm-none-eabi binutils-arm-none-eabi`. You will need to enter your password during the installation.
-3. Install Python dependencies: `pip3 install pyyaml ndspy`
+2. Run the following command to install the required tools: `sudo apt install build-essential cmake git python3-pip gcc-arm-none-eabi binutils-arm-none-eabi`. You will need to enter your password during the installation.
+3. Install Python dependencies: `pip3 install pyyaml ndspy --break-system-packages`
 4. Compile `armips`:
     1. Run `git clone --recursive https://github.com/Kingcom/armips.git` to download the source code.
     2. Run `cd armips` to enter the directory.
@@ -32,14 +38,14 @@ You can install c-of-time on Ubuntu or Debian using the following methods. The s
 ## Fedora
 
 1. Open the Terminal app in your Applications menu. The exact steps might vary based on your desktop environment.
-2. Run the following command to install the required tools: `sudo dnf install @development-tools gcc-c++ cmake python3-pip arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs`. You will need to enter your password during the installation.
+2. Run the following command to install the required tools: `sudo dnf install @development-tools gcc-c++ cmake gif git python3-pip arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs`. You will need to enter your password during the installation.
 3. You can now continue with the steps 3-10 of the Ubuntu/Debian method above.
 
 ## Arch Linux
 
 1. Open the Terminal app. The exact steps vary based on your desktop environment.
 2. Run the following command to install the required tools: `sudo pacman -Syu base-devel git python python-pip arm-none-eabi-gcc arm-none-eabi-binutils`. You will need to enter your password during the installation.
-3. Install Python dependencies: `pip3 install pyyaml ndspy`
+3. Install Python dependencies: `pip3 install pyyaml ndspy --break-system-packages`
 4. Install the [armips package](https://aur.archlinux.org/packages/armips) via the Arch User Repository (AUR). Please refer to the [Arch Wiki](https://wiki.archlinux.org/title/Arch_User_Repository) for instructions.
 5. You can now continue with the steps 5-10 of the Ubuntu/Debian method above.
 

--- a/install_linux.md
+++ b/install_linux.md
@@ -38,7 +38,7 @@ You can install c-of-time on Ubuntu or Debian using the following methods. The s
 ## Fedora
 
 1. Open the Terminal app in your Applications menu. The exact steps might vary based on your desktop environment.
-2. Run the following command to install the required tools: `sudo dnf install @development-tools gcc-c++ cmake gif git python3-pip arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs`. You will need to enter your password during the installation.
+2. Run the following command to install the required tools: `sudo dnf install @development-tools gcc-c++ cmake git python3-pip arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs`. You will need to enter your password during the installation.
 3. You can now continue with the steps 3-10 of the Ubuntu/Debian method above.
 
 ## Arch Linux


### PR DESCRIPTION
*(Most of this has already been discussed on Discord, but I'll go over everything again for the sake of recordkeeping.)*

Link-time optimization is known to fail with gcc-arm-none-eabi version 10.3.1.
<img width="1556" height="230" alt="image" src="https://github.com/user-attachments/assets/b37ff7cd-6073-44ca-a719-4f4aaef22ed2" />
<img width="647" height="97" alt="image" src="https://github.com/user-attachments/assets/46ed39e6-8f3f-4811-9f9d-40d76df33faa" />
> (Screenshots courtesy of @StolenBurrito)

[`gcc-arm-none-eabi`](https://pkgs.org/download/gcc-arm-none-eabi) updates are no longer published on Ubuntu Universe for Ubuntu 22; it's stuck on version 10.3.1. As Ubuntu 22 is stuck with a GCC that is known to encounter errors with the c-of-time Makefile, it's in our best interest to update the recommended version to Ubuntu 24, a version that can use `gcc-arm-none-eabi` version 13.2.1, a GCC version that does not have these issues.

I used a distrobox container with Ubuntu 24 to verify everything was working as it should, and it led me to make a few other updates to the install guide. The full list of changes is below:
* Bumped tested Ubuntu version to 24.04.
* Added a notice about the aforementioned issues with Ubuntu 22; if this is too wordy, we can cut it down or remove it.
* Added git as a dependency for Ubuntu/Debian and Fedora (it was already there for Arch), as it's not guaranteed to be installed by default and is needed to clone both armips and c-of-time. I believe most modern distros bundle it, but there's no harm in making sure for the rare case that it isn't bundled.
* Added `--break-system-packages` to the pip command; as per [PEP 668](https://peps.python.org/pep-0668/), pip will demand that you either make a virtual environment or specifically include a flag to let it install on a system level. `--break-system-packages` is the easiest option and keeps everything functioning exactly as it has been, but does defeat the point of PEP 668. Alternatively, we could do larger revisions to instruct the user to create a venv, but this would also require some Makefile updates to specify the venv as the location of the Python executable. If the venv approach would be preferable, say the word and I'll get that arranged.